### PR TITLE
Remove direct link

### DIFF
--- a/views/repoReady.handlebars
+++ b/views/repoReady.handlebars
@@ -1,6 +1,12 @@
 <h3>Your {{ courseName }} repository is ready!</h3>
 <p>
-  You will submit all course assignments through this repository.
-  We recommend you bookmark your repository for easy access.
+  You will submit all course assignments through this repository:
 </p>
-<a class="btn btn-github" target="_blank" href="{{studentRepoUrl}}">Go to repository</a>
+<ul>
+  <li>
+    <code>{{studentRepoUrl}}</code>
+  </li>
+  <li>
+    Follow your course-specific instructions on what to do next (you will usually not visit your git URL directly).
+  </li>
+</ul>


### PR DESCRIPTION
Lots of issues come from students using the "getting started with github" instructions in a default repo.  This removes the link directly to the repo and provides them it in text form instead.